### PR TITLE
avoid having 'sh -c "..."' as pid 1 (init) in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN echo http://dl-4.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositorie
 	npm cache clean && rm -rf $HOME/.npm && \
 	apk del curl git gcc g++ make python unzip && rm -r /etc/ssl /var/cache/apk/* /tmp/*
 
-CMD ${InstallationDir}/start.sh
+CMD ["./start.sh"]
 
 VOLUME /data/db
 

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 eyeos-service-ready-notify-cli &
-eyeos-run-server --serf mongod
+exec eyeos-run-server --serf mongod


### PR DESCRIPTION
Facts:
- Pid 1 is the one that receives SIGTERM when we run `docker stop`.
- Shell scripts swallow signals.
- If the `CMD` sentence in `Dockerfile` is not in the form of a JSON
  array, docker launches a shell to execute the `CMD`, using `sh -c
  "$CMD"`.

So, our pid 1 in the container was a `sh -c "..."` process, that did not
pass signals to `eyeos-run-server`, so `eyeos-run-server` never received
a `SIGTERM` when someone did `docker stop`, and docker ended up killing
our containers in a not-so-graceful way.

To avoid this, we need to specify the `CMD` in "execform" (see
https://docs.docker.com/engine/reference/builder/#cmd) so the pid 1
process in the container is our command instead of a wrapping `sh -c`.
In the CMD sentence, environment variables are not expanded, so we
cannot use `${InstallationDir}` or others there now (we could do that
before because the literal `${InstallationDir}` was passed to the shell,
and the shell was evaluating it, but now that no shell is present we
cannot use envars in the `CMD`. To avoid this we set a shell script as
our CMD, and in the script we `exec` the full command that we had on the
initial CMD. The `exec` part is very important, because this makes the
new process to replace the script process, so now eyeos-run-server is
the new pid 1 process, and it will receive all signals.
